### PR TITLE
Migrate GORM to v2

### DIFF
--- a/controllers/animal.go
+++ b/controllers/animal.go
@@ -5,6 +5,7 @@ import (
 	"animal-rescue-be/helpers"
 	"animal-rescue-be/models"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -17,7 +18,7 @@ func (ctrl AnimalController) GetAnimals(context *gin.Context) {
 		Select("AA.id, AA.name, AA.scientific_name, AA.created_at, ACS.name conservation_status, ACS.abbreviation conservation_abbreviation, AAC.name classification_name").
 		Joins("INNER JOIN \"AP_Conservation_Status\" ACS ON ACS.id = AA.conservation_status_id").
 		Joins("INNER JOIN \"AP_Animal_Classification\" AAC ON AAC.id = AA.classification_id").
-		Where("AA.is_deleted = ?", 0).
+		Where("AA.is_deleted = ?", strconv.FormatInt(int64(0), 2)).
 		Find(&animals).Error
 	helpers.HandleErr(err)
 

--- a/database/database.go
+++ b/database/database.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/jinzhu/gorm"
-	_ "github.com/lib/pq"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 )
 
 var DB *gorm.DB
@@ -35,22 +35,23 @@ func initEnvVariables() {
 func InitDatabase() {
 	initEnvVariables()
 	psqlConnInfo := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s", DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME)
-	database, err := gorm.Open("postgres", psqlConnInfo)
+	database, err := gorm.Open(postgres.Open(psqlConnInfo), &gorm.Config{})
 	helpers.HandleErr(err)
 	// database.LogMode(true) Enable to debug query built by gorm
+	db, err := database.DB()
 
 	maxIddleConns, err := strconv.Atoi(DB_MAX_IDLE_CONNS)
 	if err != nil {
 		helpers.HandleErr(err)
 	} else {
-		database.DB().SetMaxIdleConns(maxIddleConns)
+		db.SetMaxIdleConns(maxIddleConns)
 	}
 
 	maxOpenConns, err := strconv.Atoi(DB_MAX_OPEN_CONNS)
 	if err != nil {
 		helpers.HandleErr(err)
 	} else {
-		database.DB().SetMaxOpenConns(maxOpenConns)
+		db.SetMaxOpenConns(maxOpenConns)
 	}
 
 	DB = database

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,10 @@ go 1.18
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/gin-gonic/gin v1.8.0
-	github.com/jinzhu/gorm v1.9.16
 	github.com/joho/godotenv v1.4.0
-	github.com/lib/pq v1.1.1
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.20.0
-	github.com/stretchr/testify v1.7.1
+	github.com/stretchr/testify v1.8.0
 
 )
 
@@ -23,7 +21,16 @@ require (
 	github.com/go-playground/validator/v10 v10.11.0 // indirect
 	github.com/goccy/go-json v0.9.7 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.13.0 // indirect
+	github.com/jackc/pgio v1.0.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.3.1 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/pgtype v1.12.0 // indirect
+	github.com/jackc/pgx/v4 v4.17.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
@@ -34,7 +41,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
-	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/net v0.0.0-20220531201128-c960675eff93 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
@@ -42,4 +49,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/postgres v1.4.5 // indirect
+	gorm.io/gorm v1.24.2 // indirect
 )

--- a/tests/unit/animal_test.go
+++ b/tests/unit/animal_test.go
@@ -5,7 +5,6 @@ import (
 	"animal-rescue-be/models"
 	"database/sql"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,9 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
-	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 )
 
 type result struct {
@@ -32,7 +33,7 @@ func TestAnimalController(t *testing.T) {
 			db, mock, err = sqlmock.New() // mock sql.DB
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, err = gorm.Open("postgres", db) // open gorm db
+			_, err = gorm.Open(postgres.New(postgres.Config{Conn: db}), &gorm.Config{}) // open gorm db
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 


### PR DESCRIPTION
### Summary
> Migrate our GORM v1 to v2

### Changelog
- Removed GORM v1 packages
- Added GORM v2 
- Changed db connection
- Fixed an animal controller error

### Ticket 
https://github.com/akurey/animal-rescue-backend/issues/[39]

### Solution
- Change out GORM version to v2, check all the enpoints to verify everything is working fine, fixed an issue with the animal endpoint and changed the db connection for the v2. 